### PR TITLE
Fixing queen slime mult bug

### DIFF
--- a/modules/jokers/queenslime.lua
+++ b/modules/jokers/queenslime.lua
@@ -10,7 +10,7 @@ SMODS.Joker{
     perishable_compat = true,
     unlocked = true,
     discovered = true,
-    config = { extra = { Xmult = 1} },
+    config = { extra = { Xmult = 0.5} },
 
     loc_vars = function(self, info_queue, card)
         return {vars = {card.ability.extra.Xmult, (G.jokers and G.jokers.cards and #G.jokers.cards or 0)*card.ability.extra.Xmult}}
@@ -19,7 +19,7 @@ SMODS.Joker{
     calculate = function(self, card, context)
         if context.cardarea == G.jokers and context.joker_main then
             return{ 
-                Xmult = (G.jokers and G.jokers.cards and #G.jokers.cards or 0)*card.ability.extra.Xmult
+                Xmult = 1 + (G.jokers and G.jokers.cards and #G.jokers.cards or 0)*card.ability.extra.Xmult
             }
         end
     end

--- a/modules/jokers/slimestaff.lua
+++ b/modules/jokers/slimestaff.lua
@@ -18,7 +18,7 @@ SMODS.Joker{
     calculate = function(self, card, context)
         if context.cardarea == G.jokers and context.joker_main then
             return{ 
-                xchips = (G.jokers and G.jokers.cards and #G.jokers.cards or 0)*card.ability.extra.xchips
+                xchips = 1 + (G.jokers and G.jokers.cards and #G.jokers.cards or 0)*card.ability.extra.xchips
             }
         end
     end


### PR DESCRIPTION
changed queen slime xmult from x1 to x0.5 and added a base x1 mult so that mult values arent less than 1 when you only have one joker for both queen slime and slime staff